### PR TITLE
Support all current LTS node versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: actions/setup-node@master
       with:
-        node-version: 13
+        node-version: 12
     - name: Install dependencies 
       run: npm i
     - name: Lint
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: actions/setup-node@master
       with:
-        node-version: 13
+        node-version: 12
     - name: Install dependencies 
       run: npm i
     - name: Coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [10, 12, 13]
+        node: [10, 12]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
CI test have been updated to use all current LTS node versions and lint and coverage tests now are run using the most current LTS node version.