### PR TITLE
Remove pull request limit for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,3 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 30


### PR DESCRIPTION
Removed the limit of open pull requests that dependabot can open